### PR TITLE
Disable deprecated canonifyURLs for multi-domain support

### DIFF
--- a/biosugar0/config.toml
+++ b/biosugar0/config.toml
@@ -22,7 +22,7 @@ publishDir   = "public"
 buildDrafts  = false
 buildFuture  = false
 buildExpored = false
-canonifyURLs = true
+canonifyURLs = false
 
 enableRobotsTXT = true
 enableGitInfo   = false


### PR DESCRIPTION
## Summary

- `canonifyURLs=true` が全相対URLをbaseURL（本番ドメイン）で絶対URLに変換していた
- dev/preview環境で別ドメインからアクセスすると、CSS/JSのSRI整合性チェックがCORSエラーでブロック
- `canonifyURLs` はHugo 0.37で非推奨の設定

## Test plan

- [ ] dev環境 (`biosugar0-com-dev.a-worker.workers.dev`) でCSS/JSが正常にロードされること
- [ ] 本番環境 (`www.biosugar0.com`) で表示が変わらないこと